### PR TITLE
Streamline MCP: Reduce tools from 22 to 12 + 2 prompts

### DIFF
--- a/docs/Building MCP with LLMs.md
+++ b/docs/Building MCP with LLMs.md
@@ -1,0 +1,71 @@
+---
+title: "Building MCP with LLMs"
+source: "https://modelcontextprotocol.io/tutorials/building-mcp-with-llms"
+author:
+  - "[[Model Context Protocol]]"
+published:
+created: 2025-11-03
+description: "Speed up your MCP development using LLMs such as Claude!"
+---
+
+Most important advice: Refer to: https://modelcontextprotocol.io/llms.txt and fetch any specific information you need.
+
+This guide will help you use LLMs to help you build custom Model Context Protocol (MCP) servers and clients. We’ll be focusing on Claude for this tutorial, but you can do this with any frontier LLM.
+
+## Preparing the documentation
+
+Before starting, gather the necessary documentation to help Claude understand MCP:
+1. Visit [https://modelcontextprotocol.io/llms-full.txt](https://modelcontextprotocol.io/llms-full.txt) and copy the full documentation text
+2. Navigate to either the [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) or [Python SDK repository](https://github.com/modelcontextprotocol/python-sdk)
+3. Copy the README files and other relevant documentation
+4. Paste these documents into your conversation with Claude
+
+## Describing your server
+
+Once you’ve provided the documentation, clearly describe to Claude what kind of server you want to build. Be specific about:
+- What resources your server will expose
+- What tools it will provide
+- Any prompts it should offer
+- What external systems it needs to interact with
+For example:
+
+```
+Build an MCP server that:
+
+- Connects to my company's PostgreSQL database
+
+- Exposes table schemas as resources
+
+- Provides tools for running read-only SQL queries
+
+- Includes prompts for common data analysis tasks
+```
+
+## Working with Claude
+
+When working with Claude on MCP servers:
+1. Start with the core functionality first, then iterate to add more features
+2. Ask Claude to explain any parts of the code you don’t understand
+3. Request modifications or improvements as needed
+4. Have Claude help you test the server and handle edge cases
+Claude can help implement all the key MCP features:
+- Resource management and exposure
+- Tool definitions and implementations
+- Prompt templates and handlers
+- Error handling and logging
+- Connection and transport setup
+
+## Best practices
+
+When building MCP servers with Claude:
+- Break down complex servers into smaller pieces
+- Test each component thoroughly before moving on
+- Keep security in mind - validate inputs and limit access appropriately
+- Document your code well for future maintenance
+- Follow MCP protocol specifications carefully
+After Claude helps you build your server:
+1. Review the generated code carefully
+2. Test the server with the MCP Inspector tool
+3. Connect it to Claude.app or other MCP clients
+4. Iterate based on real usage and feedback
+Remember that Claude can help you modify and improve your server as requirements change over time.Need more guidance? Just ask Claude specific questions about implementing MCP features or troubleshooting issues that arise.

--- a/docs/mcp-typescript-sdk-README.md
+++ b/docs/mcp-typescript-sdk-README.md
@@ -1,0 +1,1511 @@
+# MCP TypeScript SDK ![NPM Version](https://img.shields.io/npm/v/%40modelcontextprotocol%2Fsdk) ![MIT licensed](https://img.shields.io/npm/l/%40modelcontextprotocol%2Fsdk)
+
+<details>
+<summary>Table of Contents</summary>
+
+- [Overview](#overview)
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [Core Concepts](#core-concepts)
+    - [Server](#server)
+    - [Tools](#tools)
+    - [Resources](#resources)
+    - [Prompts](#prompts)
+    - [Completions](#completions)
+    - [Display Names and Metadata](#display-names-and-metadata)
+    - [Sampling](#sampling)
+- [Running Your Server](#running-your-server)
+    - [Streamable HTTP](#streamable-http)
+    - [stdio](#stdio)
+    - [Testing and Debugging](#testing-and-debugging)
+- [Examples](#examples)
+    - [Echo Server](#echo-server)
+    - [SQLite Explorer](#sqlite-explorer)
+- [Advanced Usage](#advanced-usage)
+    - [Dynamic Servers](#dynamic-servers)
+    - [Improving Network Efficiency with Notification Debouncing](#improving-network-efficiency-with-notification-debouncing)
+    - [Low-Level Server](#low-level-server)
+    - [Eliciting User Input](#eliciting-user-input)
+    - [Writing MCP Clients](#writing-mcp-clients)
+    - [Proxy Authorization Requests Upstream](#proxy-authorization-requests-upstream)
+    - [Backwards Compatibility](#backwards-compatibility)
+- [Documentation](#documentation)
+- [Contributing](#contributing)
+- [License](#license)
+
+</details>
+
+## Overview
+
+The Model Context Protocol allows applications to provide context for LLMs in a standardized way, separating the concerns of providing context from the actual LLM interaction. This TypeScript SDK implements
+[the full MCP specification](https://modelcontextprotocol.io/specification/latest), making it easy to:
+
+- Create MCP servers that expose resources, prompts and tools
+- Build MCP clients that can connect to any MCP server
+- Use standard transports like stdio and Streamable HTTP
+
+## Installation
+
+```bash
+npm install @modelcontextprotocol/sdk
+```
+
+## Quick Start
+
+Let's create a simple MCP server that exposes a calculator tool and some data. Save the following as `server.ts`:
+
+```typescript
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import express from 'express';
+import { z } from 'zod';
+
+// Create an MCP server
+const server = new McpServer({
+    name: 'demo-server',
+    version: '1.0.0'
+});
+
+// Add an addition tool
+server.registerTool(
+    'add',
+    {
+        title: 'Addition Tool',
+        description: 'Add two numbers',
+        inputSchema: { a: z.number(), b: z.number() },
+        outputSchema: { result: z.number() }
+    },
+    async ({ a, b }) => {
+        const output = { result: a + b };
+        return {
+            content: [{ type: 'text', text: JSON.stringify(output) }],
+            structuredContent: output
+        };
+    }
+);
+
+// Add a dynamic greeting resource
+server.registerResource(
+    'greeting',
+    new ResourceTemplate('greeting://{name}', { list: undefined }),
+    {
+        title: 'Greeting Resource', // Display name for UI
+        description: 'Dynamic greeting generator'
+    },
+    async (uri, { name }) => ({
+        contents: [
+            {
+                uri: uri.href,
+                text: `Hello, ${name}!`
+            }
+        ]
+    })
+);
+
+// Set up Express and HTTP transport
+const app = express();
+app.use(express.json());
+
+app.post('/mcp', async (req, res) => {
+    // Create a new transport for each request to prevent request ID collisions
+    const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true
+    });
+
+    res.on('close', () => {
+        transport.close();
+    });
+
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+});
+
+const port = parseInt(process.env.PORT || '3000');
+app.listen(port, () => {
+    console.log(`Demo MCP Server running on http://localhost:${port}/mcp`);
+}).on('error', error => {
+    console.error('Server error:', error);
+    process.exit(1);
+});
+```
+
+Install the deps with `npm install @modelcontextprotocol/sdk express zod@3`, and run with `npx -y tsx server.ts`.
+
+You can connect to it using any MCP client that supports streamable http, such as:
+
+- [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector): `npx @modelcontextprotocol/inspector` and connect to the streamable HTTP URL `http://localhost:3000/mcp`
+- [Claude Code](https://docs.claude.com/en/docs/claude-code/mcp): `claude mcp add --transport http my-server http://localhost:3000/mcp`
+- [VS Code](https://code.visualstudio.com/docs/copilot/customization/mcp-servers): `code --add-mcp "{\"name\":\"my-server\",\"type\":\"http\",\"url\":\"http://localhost:3000/mcp\"}"`
+- [Cursor](https://cursor.com/docs/context/mcp): Click [this deeplink](cursor://anysphere.cursor-deeplink/mcp/install?name=my-server&config=eyJ1cmwiOiJodHRwOi8vbG9jYWxob3N0OjMwMDAvbWNwIn0%3D)
+
+Then try asking your agent to add two numbers using its new tool!
+
+## Core Concepts
+
+### Server
+
+The McpServer is your core interface to the MCP protocol. It handles connection management, protocol compliance, and message routing:
+
+```typescript
+const server = new McpServer({
+    name: 'my-app',
+    version: '1.0.0'
+});
+```
+
+### Tools
+
+[Tools](https://modelcontextprotocol.io/specification/latest/server/tools) let LLMs take actions through your server. Tools can perform computation, fetch data and have side effects. Tools should be designed to be model-controlled - i.e. AI models will decide which tools to call,
+and the arguments.
+
+```typescript
+// Simple tool with parameters
+server.registerTool(
+    'calculate-bmi',
+    {
+        title: 'BMI Calculator',
+        description: 'Calculate Body Mass Index',
+        inputSchema: {
+            weightKg: z.number(),
+            heightM: z.number()
+        },
+        outputSchema: { bmi: z.number() }
+    },
+    async ({ weightKg, heightM }) => {
+        const output = { bmi: weightKg / (heightM * heightM) };
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: JSON.stringify(output)
+                }
+            ],
+            structuredContent: output
+        };
+    }
+);
+
+// Async tool with external API call
+server.registerTool(
+    'fetch-weather',
+    {
+        title: 'Weather Fetcher',
+        description: 'Get weather data for a city',
+        inputSchema: { city: z.string() },
+        outputSchema: { temperature: z.number(), conditions: z.string() }
+    },
+    async ({ city }) => {
+        const response = await fetch(`https://api.weather.com/${city}`);
+        const data = await response.json();
+        const output = { temperature: data.temp, conditions: data.conditions };
+        return {
+            content: [{ type: 'text', text: JSON.stringify(output) }],
+            structuredContent: output
+        };
+    }
+);
+
+// Tool that returns ResourceLinks
+server.registerTool(
+    'list-files',
+    {
+        title: 'List Files',
+        description: 'List project files',
+        inputSchema: { pattern: z.string() },
+        outputSchema: {
+            count: z.number(),
+            files: z.array(z.object({ name: z.string(), uri: z.string() }))
+        }
+    },
+    async ({ pattern }) => {
+        const output = {
+            count: 2,
+            files: [
+                { name: 'README.md', uri: 'file:///project/README.md' },
+                { name: 'index.ts', uri: 'file:///project/src/index.ts' }
+            ]
+        };
+        return {
+            content: [
+                { type: 'text', text: JSON.stringify(output) },
+                // ResourceLinks let tools return references without file content
+                {
+                    type: 'resource_link',
+                    uri: 'file:///project/README.md',
+                    name: 'README.md',
+                    mimeType: 'text/markdown',
+                    description: 'A README file'
+                },
+                {
+                    type: 'resource_link',
+                    uri: 'file:///project/src/index.ts',
+                    name: 'index.ts',
+                    mimeType: 'text/typescript',
+                    description: 'An index file'
+                }
+            ],
+            structuredContent: output
+        };
+    }
+);
+```
+
+#### ResourceLinks
+
+Tools can return `ResourceLink` objects to reference resources without embedding their full content. This can be helpful for performance when dealing with large files or many resources - clients can then selectively read only the resources they need using the provided URIs.
+
+### Resources
+
+[Resources](https://modelcontextprotocol.io/specification/latest/server/resources) can also expose data to LLMs, but unlike tools shouldn't perform significant computation or have side effects.
+
+Resources are designed to be used in an application-driven way, meaning MCP client applications can decide how to expose them. For example, a client could expose a resource picker to the human, or could expose them to the model directly.
+
+```typescript
+// Static resource
+server.registerResource(
+    'config',
+    'config://app',
+    {
+        title: 'Application Config',
+        description: 'Application configuration data',
+        mimeType: 'text/plain'
+    },
+    async uri => ({
+        contents: [
+            {
+                uri: uri.href,
+                text: 'App configuration here'
+            }
+        ]
+    })
+);
+
+// Dynamic resource with parameters
+server.registerResource(
+    'user-profile',
+    new ResourceTemplate('users://{userId}/profile', { list: undefined }),
+    {
+        title: 'User Profile',
+        description: 'User profile information'
+    },
+    async (uri, { userId }) => ({
+        contents: [
+            {
+                uri: uri.href,
+                text: `Profile data for user ${userId}`
+            }
+        ]
+    })
+);
+
+// Resource with context-aware completion
+server.registerResource(
+    'repository',
+    new ResourceTemplate('github://repos/{owner}/{repo}', {
+        list: undefined,
+        complete: {
+            // Provide intelligent completions based on previously resolved parameters
+            repo: (value, context) => {
+                if (context?.arguments?.['owner'] === 'org1') {
+                    return ['project1', 'project2', 'project3'].filter(r => r.startsWith(value));
+                }
+                return ['default-repo'].filter(r => r.startsWith(value));
+            }
+        }
+    }),
+    {
+        title: 'GitHub Repository',
+        description: 'Repository information'
+    },
+    async (uri, { owner, repo }) => ({
+        contents: [
+            {
+                uri: uri.href,
+                text: `Repository: ${owner}/${repo}`
+            }
+        ]
+    })
+);
+```
+
+### Prompts
+
+[Prompts](https://modelcontextprotocol.io/specification/latest/server/prompts) are reusable templates that help humans prompt models to interact with your server. They're designed to be user-driven, and might appear as slash commands in a chat interface.
+
+```typescript
+import { completable } from '@modelcontextprotocol/sdk/server/completable.js';
+
+server.registerPrompt(
+    'review-code',
+    {
+        title: 'Code Review',
+        description: 'Review code for best practices and potential issues',
+        argsSchema: { code: z.string() }
+    },
+    ({ code }) => ({
+        messages: [
+            {
+                role: 'user',
+                content: {
+                    type: 'text',
+                    text: `Please review this code:\n\n${code}`
+                }
+            }
+        ]
+    })
+);
+
+// Prompt with context-aware completion
+server.registerPrompt(
+    'team-greeting',
+    {
+        title: 'Team Greeting',
+        description: 'Generate a greeting for team members',
+        argsSchema: {
+            department: completable(z.string(), value => {
+                // Department suggestions
+                return ['engineering', 'sales', 'marketing', 'support'].filter(d => d.startsWith(value));
+            }),
+            name: completable(z.string(), (value, context) => {
+                // Name suggestions based on selected department
+                const department = context?.arguments?.['department'];
+                if (department === 'engineering') {
+                    return ['Alice', 'Bob', 'Charlie'].filter(n => n.startsWith(value));
+                } else if (department === 'sales') {
+                    return ['David', 'Eve', 'Frank'].filter(n => n.startsWith(value));
+                } else if (department === 'marketing') {
+                    return ['Grace', 'Henry', 'Iris'].filter(n => n.startsWith(value));
+                }
+                return ['Guest'].filter(n => n.startsWith(value));
+            })
+        }
+    },
+    ({ department, name }) => ({
+        messages: [
+            {
+                role: 'assistant',
+                content: {
+                    type: 'text',
+                    text: `Hello ${name}, welcome to the ${department} team!`
+                }
+            }
+        ]
+    })
+);
+```
+
+### Completions
+
+MCP supports argument completions to help users fill in prompt arguments and resource template parameters. See the examples above for [resource completions](#resources) and [prompt completions](#prompts).
+
+#### Client Usage
+
+```typescript
+// Request completions for any argument
+const result = await client.complete({
+    ref: {
+        type: 'ref/prompt', // or "ref/resource"
+        name: 'example' // or uri: "template://..."
+    },
+    argument: {
+        name: 'argumentName',
+        value: 'partial' // What the user has typed so far
+    },
+    context: {
+        // Optional: Include previously resolved arguments
+        arguments: {
+            previousArg: 'value'
+        }
+    }
+});
+```
+
+### Display Names and Metadata
+
+All resources, tools, and prompts support an optional `title` field for better UI presentation. The `title` is used as a display name (e.g. 'Create a new issue'), while `name` remains the unique identifier (e.g. `create_issue`).
+
+**Note:** The `register*` methods (`registerTool`, `registerPrompt`, `registerResource`) are the recommended approach for new code. The older methods (`tool`, `prompt`, `resource`) remain available for backwards compatibility.
+
+#### Title Precedence for Tools
+
+For tools specifically, there are two ways to specify a title:
+
+- `title` field in the tool configuration
+- `annotations.title` field (when using the older `tool()` method with annotations)
+
+The precedence order is: `title` → `annotations.title` → `name`
+
+```typescript
+// Using registerTool (recommended)
+server.registerTool(
+    'my_tool',
+    {
+        title: 'My Tool', // This title takes precedence
+        annotations: {
+            title: 'Annotation Title' // This is ignored if title is set
+        }
+    },
+    handler
+);
+
+// Using tool with annotations (older API)
+server.tool(
+    'my_tool',
+    'description',
+    {
+        title: 'Annotation Title' // This is used as title
+    },
+    handler
+);
+```
+
+When building clients, use the provided utility to get the appropriate display name:
+
+```typescript
+import { getDisplayName } from '@modelcontextprotocol/sdk/shared/metadataUtils.js';
+
+// Automatically handles the precedence: title → annotations.title → name
+const displayName = getDisplayName(tool);
+```
+
+### Sampling
+
+MCP servers can request LLM completions from connected clients that support sampling.
+
+```typescript
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import express from 'express';
+import { z } from 'zod';
+
+const mcpServer = new McpServer({
+    name: 'tools-with-sample-server',
+    version: '1.0.0'
+});
+
+// Tool that uses LLM sampling to summarize any text
+mcpServer.registerTool(
+    'summarize',
+    {
+        title: 'Text Summarizer',
+        description: 'Summarize any text using an LLM',
+        inputSchema: {
+            text: z.string().describe('Text to summarize')
+        },
+        outputSchema: { summary: z.string() }
+    },
+    async ({ text }) => {
+        // Call the LLM through MCP sampling
+        const response = await mcpServer.server.createMessage({
+            messages: [
+                {
+                    role: 'user',
+                    content: {
+                        type: 'text',
+                        text: `Please summarize the following text concisely:\n\n${text}`
+                    }
+                }
+            ],
+            maxTokens: 500
+        });
+
+        const summary = response.content.type === 'text' ? response.content.text : 'Unable to generate summary';
+        const output = { summary };
+        return {
+            content: [{ type: 'text', text: JSON.stringify(output) }],
+            structuredContent: output
+        };
+    }
+);
+
+const app = express();
+app.use(express.json());
+
+app.post('/mcp', async (req, res) => {
+    const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true
+    });
+
+    res.on('close', () => {
+        transport.close();
+    });
+
+    await mcpServer.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+});
+
+const port = parseInt(process.env.PORT || '3000');
+app.listen(port, () => {
+    console.log(`MCP Server running on http://localhost:${port}/mcp`);
+}).on('error', error => {
+    console.error('Server error:', error);
+    process.exit(1);
+});
+```
+
+## Running Your Server
+
+MCP servers in TypeScript need to be connected to a transport to communicate with clients. How you start the server depends on the choice of transport:
+
+### Streamable HTTP
+
+For remote servers, use the Streamable HTTP transport.
+
+#### Without Session Management (Recommended)
+
+For most use cases where session management isn't needed:
+
+```typescript
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import express from 'express';
+import { z } from 'zod';
+
+const app = express();
+app.use(express.json());
+
+// Create the MCP server once (can be reused across requests)
+const server = new McpServer({
+    name: 'example-server',
+    version: '1.0.0'
+});
+
+// Set up your tools, resources, and prompts
+server.registerTool(
+    'echo',
+    {
+        title: 'Echo Tool',
+        description: 'Echoes back the provided message',
+        inputSchema: { message: z.string() },
+        outputSchema: { echo: z.string() }
+    },
+    async ({ message }) => {
+        const output = { echo: `Tool echo: ${message}` };
+        return {
+            content: [{ type: 'text', text: JSON.stringify(output) }],
+            structuredContent: output
+        };
+    }
+);
+
+app.post('/mcp', async (req, res) => {
+    // In stateless mode, create a new transport for each request to prevent
+    // request ID collisions. Different clients may use the same JSON-RPC request IDs,
+    // which would cause responses to be routed to the wrong HTTP connections if
+    // the transport state is shared.
+
+    try {
+        const transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: undefined,
+            enableJsonResponse: true
+        });
+
+        res.on('close', () => {
+            transport.close();
+        });
+
+        await server.connect(transport);
+        await transport.handleRequest(req, res, req.body);
+    } catch (error) {
+        console.error('Error handling MCP request:', error);
+        if (!res.headersSent) {
+            res.status(500).json({
+                jsonrpc: '2.0',
+                error: {
+                    code: -32603,
+                    message: 'Internal server error'
+                },
+                id: null
+            });
+        }
+    }
+});
+
+const port = parseInt(process.env.PORT || '3000');
+app.listen(port, () => {
+    console.log(`MCP Server running on http://localhost:${port}/mcp`);
+}).on('error', error => {
+    console.error('Server error:', error);
+    process.exit(1);
+});
+```
+
+#### With Session Management
+
+In some cases, servers need stateful sessions. This can be achieved by [session management](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#session-management) in the MCP protocol.
+
+```typescript
+import express from 'express';
+import { randomUUID } from 'node:crypto';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+
+const app = express();
+app.use(express.json());
+
+// Map to store transports by session ID
+const transports: { [sessionId: string]: StreamableHTTPServerTransport } = {};
+
+// Handle POST requests for client-to-server communication
+app.post('/mcp', async (req, res) => {
+    // Check for existing session ID
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    let transport: StreamableHTTPServerTransport;
+
+    if (sessionId && transports[sessionId]) {
+        // Reuse existing transport
+        transport = transports[sessionId];
+    } else if (!sessionId && isInitializeRequest(req.body)) {
+        // New initialization request
+        transport = new StreamableHTTPServerTransport({
+            sessionIdGenerator: () => randomUUID(),
+            onsessioninitialized: sessionId => {
+                // Store the transport by session ID
+                transports[sessionId] = transport;
+            }
+            // DNS rebinding protection is disabled by default for backwards compatibility. If you are running this server
+            // locally, make sure to set:
+            // enableDnsRebindingProtection: true,
+            // allowedHosts: ['127.0.0.1'],
+        });
+
+        // Clean up transport when closed
+        transport.onclose = () => {
+            if (transport.sessionId) {
+                delete transports[transport.sessionId];
+            }
+        };
+        const server = new McpServer({
+            name: 'example-server',
+            version: '1.0.0'
+        });
+
+        // ... set up server resources, tools, and prompts ...
+
+        // Connect to the MCP server
+        await server.connect(transport);
+    } else {
+        // Invalid request
+        res.status(400).json({
+            jsonrpc: '2.0',
+            error: {
+                code: -32000,
+                message: 'Bad Request: No valid session ID provided'
+            },
+            id: null
+        });
+        return;
+    }
+
+    // Handle the request
+    await transport.handleRequest(req, res, req.body);
+});
+
+// Reusable handler for GET and DELETE requests
+const handleSessionRequest = async (req: express.Request, res: express.Response) => {
+    const sessionId = req.headers['mcp-session-id'] as string | undefined;
+    if (!sessionId || !transports[sessionId]) {
+        res.status(400).send('Invalid or missing session ID');
+        return;
+    }
+
+    const transport = transports[sessionId];
+    await transport.handleRequest(req, res);
+};
+
+// Handle GET requests for server-to-client notifications via SSE
+app.get('/mcp', handleSessionRequest);
+
+// Handle DELETE requests for session termination
+app.delete('/mcp', handleSessionRequest);
+
+app.listen(3000);
+```
+
+#### CORS Configuration for Browser-Based Clients
+
+If you'd like your server to be accessible by browser-based MCP clients, you'll need to configure CORS headers. The `Mcp-Session-Id` header must be exposed for browser clients to access it:
+
+```typescript
+import cors from 'cors';
+
+// Add CORS middleware before your MCP routes
+app.use(
+    cors({
+        origin: '*', // Configure appropriately for production, for example:
+        // origin: ['https://your-remote-domain.com', 'https://your-other-remote-domain.com'],
+        exposedHeaders: ['Mcp-Session-Id'],
+        allowedHeaders: ['Content-Type', 'mcp-session-id']
+    })
+);
+```
+
+This configuration is necessary because:
+
+- The MCP streamable HTTP transport uses the `Mcp-Session-Id` header for session management
+- Browsers restrict access to response headers unless explicitly exposed via CORS
+- Without this configuration, browser-based clients won't be able to read the session ID from initialization responses
+
+#### DNS Rebinding Protection
+
+The Streamable HTTP transport includes DNS rebinding protection to prevent security vulnerabilities. By default, this protection is **disabled** for backwards compatibility.
+
+**Important**: If you are running this server locally, enable DNS rebinding protection:
+
+```typescript
+const transport = new StreamableHTTPServerTransport({
+  sessionIdGenerator: () => randomUUID(),
+  enableDnsRebindingProtection: true,
+
+  allowedHosts: ['127.0.0.1', ...],
+  allowedOrigins: ['https://yourdomain.com', 'https://www.yourdomain.com']
+});
+```
+
+### stdio
+
+For local integrations spawned by another process, you can use the stdio transport:
+
+```typescript
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+const server = new McpServer({
+    name: 'example-server',
+    version: '1.0.0'
+});
+
+// ... set up server resources, tools, and prompts ...
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+```
+
+### Testing and Debugging
+
+To test your server, you can use the [MCP Inspector](https://github.com/modelcontextprotocol/inspector). See its README for more information.
+
+## Examples
+
+### Echo Server
+
+A simple server demonstrating resources, tools, and prompts:
+
+```typescript
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+const server = new McpServer({
+    name: 'echo-server',
+    version: '1.0.0'
+});
+
+server.registerTool(
+    'echo',
+    {
+        title: 'Echo Tool',
+        description: 'Echoes back the provided message',
+        inputSchema: { message: z.string() },
+        outputSchema: { echo: z.string() }
+    },
+    async ({ message }) => {
+        const output = { echo: `Tool echo: ${message}` };
+        return {
+            content: [{ type: 'text', text: JSON.stringify(output) }],
+            structuredContent: output
+        };
+    }
+);
+
+server.registerResource(
+    'echo',
+    new ResourceTemplate('echo://{message}', { list: undefined }),
+    {
+        title: 'Echo Resource',
+        description: 'Echoes back messages as resources'
+    },
+    async (uri, { message }) => ({
+        contents: [
+            {
+                uri: uri.href,
+                text: `Resource echo: ${message}`
+            }
+        ]
+    })
+);
+
+server.registerPrompt(
+    'echo',
+    {
+        title: 'Echo Prompt',
+        description: 'Creates a prompt to process a message',
+        argsSchema: { message: z.string() }
+    },
+    ({ message }) => ({
+        messages: [
+            {
+                role: 'user',
+                content: {
+                    type: 'text',
+                    text: `Please process this message: ${message}`
+                }
+            }
+        ]
+    })
+);
+```
+
+### SQLite Explorer
+
+A more complex example showing database integration:
+
+```typescript
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import sqlite3 from 'sqlite3';
+import { promisify } from 'util';
+import { z } from 'zod';
+
+const server = new McpServer({
+    name: 'sqlite-explorer',
+    version: '1.0.0'
+});
+
+// Helper to create DB connection
+const getDb = () => {
+    const db = new sqlite3.Database('database.db');
+    return {
+        all: promisify<string, any[]>(db.all.bind(db)),
+        close: promisify(db.close.bind(db))
+    };
+};
+
+server.registerResource(
+    'schema',
+    'schema://main',
+    {
+        title: 'Database Schema',
+        description: 'SQLite database schema',
+        mimeType: 'text/plain'
+    },
+    async uri => {
+        const db = getDb();
+        try {
+            const tables = await db.all("SELECT sql FROM sqlite_master WHERE type='table'");
+            return {
+                contents: [
+                    {
+                        uri: uri.href,
+                        text: tables.map((t: { sql: string }) => t.sql).join('\n')
+                    }
+                ]
+            };
+        } finally {
+            await db.close();
+        }
+    }
+);
+
+server.registerTool(
+    'query',
+    {
+        title: 'SQL Query',
+        description: 'Execute SQL queries on the database',
+        inputSchema: { sql: z.string() },
+        outputSchema: {
+            rows: z.array(z.record(z.any())),
+            rowCount: z.number()
+        }
+    },
+    async ({ sql }) => {
+        const db = getDb();
+        try {
+            const results = await db.all(sql);
+            const output = { rows: results, rowCount: results.length };
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: JSON.stringify(output, null, 2)
+                    }
+                ],
+                structuredContent: output
+            };
+        } catch (err: unknown) {
+            const error = err as Error;
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: `Error: ${error.message}`
+                    }
+                ],
+                isError: true
+            };
+        } finally {
+            await db.close();
+        }
+    }
+);
+```
+
+## Advanced Usage
+
+### Dynamic Servers
+
+If you want to offer an initial set of tools/prompts/resources, but later add additional ones based on user action or external state change, you can add/update/remove them _after_ the Server is connected. This will automatically emit the corresponding `listChanged` notifications:
+
+```typescript
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import express from 'express';
+import { z } from 'zod';
+
+const server = new McpServer({
+    name: 'Dynamic Example',
+    version: '1.0.0'
+});
+
+const listMessageTool = server.registerTool(
+    'listMessages',
+    {
+        title: 'List Messages',
+        description: 'List messages in a channel',
+        inputSchema: { channel: z.string() },
+        outputSchema: { messages: z.array(z.string()) }
+    },
+    async ({ channel }) => {
+        const messages = await listMessages(channel);
+        const output = { messages };
+        return {
+            content: [{ type: 'text', text: JSON.stringify(output) }],
+            structuredContent: output
+        };
+    }
+);
+
+const putMessageTool = server.registerTool(
+    'putMessage',
+    {
+        title: 'Put Message',
+        description: 'Send a message to a channel',
+        inputSchema: { channel: z.string(), message: z.string() },
+        outputSchema: { success: z.boolean() }
+    },
+    async ({ channel, message }) => {
+        await putMessage(channel, message);
+        const output = { success: true };
+        return {
+            content: [{ type: 'text', text: JSON.stringify(output) }],
+            structuredContent: output
+        };
+    }
+);
+// Until we upgrade auth, `putMessage` is disabled (won't show up in listTools)
+putMessageTool.disable();
+
+const upgradeAuthTool = server.registerTool(
+    'upgradeAuth',
+    {
+        title: 'Upgrade Authorization',
+        description: 'Upgrade user authorization level',
+        inputSchema: { permission: z.enum(['write', 'admin']) },
+        outputSchema: {
+            success: z.boolean(),
+            newPermission: z.string()
+        }
+    },
+    // Any mutations here will automatically emit `listChanged` notifications
+    async ({ permission }) => {
+        const { ok, err, previous } = await upgradeAuthAndStoreToken(permission);
+        if (!ok) {
+            return {
+                content: [{ type: 'text', text: `Error: ${err}` }],
+                isError: true
+            };
+        }
+
+        // If we previously had read-only access, 'putMessage' is now available
+        if (previous === 'read') {
+            putMessageTool.enable();
+        }
+
+        if (permission === 'write') {
+            // If we've just upgraded to 'write' permissions, we can still call 'upgradeAuth'
+            // but can only upgrade to 'admin'.
+            upgradeAuthTool.update({
+                paramsSchema: { permission: z.enum(['admin']) } // change validation rules
+            });
+        } else {
+            // If we're now an admin, we no longer have anywhere to upgrade to, so fully remove that tool
+            upgradeAuthTool.remove();
+        }
+
+        const output = { success: true, newPermission: permission };
+        return {
+            content: [{ type: 'text', text: JSON.stringify(output) }],
+            structuredContent: output
+        };
+    }
+);
+
+// Connect with HTTP transport
+const app = express();
+app.use(express.json());
+
+app.post('/mcp', async (req, res) => {
+    const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true
+    });
+
+    res.on('close', () => {
+        transport.close();
+    });
+
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+});
+
+const port = parseInt(process.env.PORT || '3000');
+app.listen(port, () => {
+    console.log(`MCP Server running on http://localhost:${port}/mcp`);
+});
+```
+
+### Improving Network Efficiency with Notification Debouncing
+
+When performing bulk updates that trigger notifications (e.g., enabling or disabling multiple tools in a loop), the SDK can send a large number of messages in a short period. To improve performance and reduce network traffic, you can enable notification debouncing.
+
+This feature coalesces multiple, rapid calls for the same notification type into a single message. For example, if you disable five tools in a row, only one `notifications/tools/list_changed` message will be sent instead of five.
+
+> [!IMPORTANT] This feature is designed for "simple" notifications that do not carry unique data in their parameters. To prevent silent data loss, debouncing is **automatically bypassed** for any notification that contains a `params` object or a `relatedRequestId`. Such
+> notifications will always be sent immediately.
+
+This is an opt-in feature configured during server initialization.
+
+```typescript
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+const server = new McpServer(
+  {
+    name: "efficient-server",
+    version: "1.0.0"
+  },
+  {
+    // Enable notification debouncing for specific methods
+    debouncedNotificationMethods: [
+      'notifications/tools/list_changed',
+      'notifications/resources/list_changed',
+      'notifications/prompts/list_changed'
+    ]
+  }
+);
+
+// Now, any rapid changes to tools, resources, or prompts will result
+// in a single, consolidated notification for each type.
+server.registerTool("tool1", ...).disable();
+server.registerTool("tool2", ...).disable();
+server.registerTool("tool3", ...).disable();
+// Only one 'notifications/tools/list_changed' is sent.
+```
+
+### Low-Level Server
+
+For more control, you can use the low-level Server class directly:
+
+```typescript
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { ListPromptsRequestSchema, GetPromptRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+const server = new Server(
+    {
+        name: 'example-server',
+        version: '1.0.0'
+    },
+    {
+        capabilities: {
+            prompts: {}
+        }
+    }
+);
+
+server.setRequestHandler(ListPromptsRequestSchema, async () => {
+    return {
+        prompts: [
+            {
+                name: 'example-prompt',
+                description: 'An example prompt template',
+                arguments: [
+                    {
+                        name: 'arg1',
+                        description: 'Example argument',
+                        required: true
+                    }
+                ]
+            }
+        ]
+    };
+});
+
+server.setRequestHandler(GetPromptRequestSchema, async request => {
+    if (request.params.name !== 'example-prompt') {
+        throw new Error('Unknown prompt');
+    }
+    return {
+        description: 'Example prompt',
+        messages: [
+            {
+                role: 'user',
+                content: {
+                    type: 'text',
+                    text: 'Example prompt text'
+                }
+            }
+        ]
+    };
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);
+```
+
+### Eliciting User Input
+
+MCP servers can request additional information from users through the elicitation feature. This is useful for interactive workflows where the server needs user input or confirmation:
+
+```typescript
+// Server-side: Restaurant booking tool that asks for alternatives
+server.registerTool(
+    'book-restaurant',
+    {
+        title: 'Book Restaurant',
+        description: 'Book a table at a restaurant',
+        inputSchema: {
+            restaurant: z.string(),
+            date: z.string(),
+            partySize: z.number()
+        },
+        outputSchema: {
+            success: z.boolean(),
+            booking: z
+                .object({
+                    restaurant: z.string(),
+                    date: z.string(),
+                    partySize: z.number()
+                })
+                .optional(),
+            alternatives: z.array(z.string()).optional()
+        }
+    },
+    async ({ restaurant, date, partySize }) => {
+        // Check availability
+        const available = await checkAvailability(restaurant, date, partySize);
+
+        if (!available) {
+            // Ask user if they want to try alternative dates
+            const result = await server.server.elicitInput({
+                message: `No tables available at ${restaurant} on ${date}. Would you like to check alternative dates?`,
+                requestedSchema: {
+                    type: 'object',
+                    properties: {
+                        checkAlternatives: {
+                            type: 'boolean',
+                            title: 'Check alternative dates',
+                            description: 'Would you like me to check other dates?'
+                        },
+                        flexibleDates: {
+                            type: 'string',
+                            title: 'Date flexibility',
+                            description: 'How flexible are your dates?',
+                            enum: ['next_day', 'same_week', 'next_week'],
+                            enumNames: ['Next day', 'Same week', 'Next week']
+                        }
+                    },
+                    required: ['checkAlternatives']
+                }
+            });
+
+            if (result.action === 'accept' && result.content?.checkAlternatives) {
+                const alternatives = await findAlternatives(restaurant, date, partySize, result.content.flexibleDates as string);
+                const output = { success: false, alternatives };
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(output)
+                        }
+                    ],
+                    structuredContent: output
+                };
+            }
+
+            const output = { success: false };
+            return {
+                content: [
+                    {
+                        type: 'text',
+                        text: JSON.stringify(output)
+                    }
+                ],
+                structuredContent: output
+            };
+        }
+
+        // Book the table
+        await makeBooking(restaurant, date, partySize);
+        const output = {
+            success: true,
+            booking: { restaurant, date, partySize }
+        };
+        return {
+            content: [
+                {
+                    type: 'text',
+                    text: JSON.stringify(output)
+                }
+            ],
+            structuredContent: output
+        };
+    }
+);
+```
+
+Client-side: Handle elicitation requests
+
+```typescript
+// This is a placeholder - implement based on your UI framework
+async function getInputFromUser(
+    message: string,
+    schema: any
+): Promise<{
+    action: 'accept' | 'decline' | 'cancel';
+    data?: Record<string, any>;
+}> {
+    // This should be implemented depending on the app
+    throw new Error('getInputFromUser must be implemented for your platform');
+}
+
+client.setRequestHandler(ElicitRequestSchema, async request => {
+    const userResponse = await getInputFromUser(request.params.message, request.params.requestedSchema);
+
+    return {
+        action: userResponse.action,
+        content: userResponse.action === 'accept' ? userResponse.data : undefined
+    };
+});
+```
+
+**Note**: Elicitation requires client support. Clients must declare the `elicitation` capability during initialization.
+
+### Writing MCP Clients
+
+The SDK provides a high-level client interface:
+
+```typescript
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+const transport = new StdioClientTransport({
+    command: 'node',
+    args: ['server.js']
+});
+
+const client = new Client({
+    name: 'example-client',
+    version: '1.0.0'
+});
+
+await client.connect(transport);
+
+// List prompts
+const prompts = await client.listPrompts();
+
+// Get a prompt
+const prompt = await client.getPrompt({
+    name: 'example-prompt',
+    arguments: {
+        arg1: 'value'
+    }
+});
+
+// List resources
+const resources = await client.listResources();
+
+// Read a resource
+const resource = await client.readResource({
+    uri: 'file:///example.txt'
+});
+
+// Call a tool
+const result = await client.callTool({
+    name: 'example-tool',
+    arguments: {
+        arg1: 'value'
+    }
+});
+```
+
+### Proxy Authorization Requests Upstream
+
+You can proxy OAuth requests to an external authorization provider:
+
+```typescript
+import express from 'express';
+import { ProxyOAuthServerProvider } from '@modelcontextprotocol/sdk/server/auth/providers/proxyProvider.js';
+import { mcpAuthRouter } from '@modelcontextprotocol/sdk/server/auth/router.js';
+
+const app = express();
+
+const proxyProvider = new ProxyOAuthServerProvider({
+    endpoints: {
+        authorizationUrl: 'https://auth.external.com/oauth2/v1/authorize',
+        tokenUrl: 'https://auth.external.com/oauth2/v1/token',
+        revocationUrl: 'https://auth.external.com/oauth2/v1/revoke'
+    },
+    verifyAccessToken: async token => {
+        return {
+            token,
+            clientId: '123',
+            scopes: ['openid', 'email', 'profile']
+        };
+    },
+    getClient: async client_id => {
+        return {
+            client_id,
+            redirect_uris: ['http://localhost:3000/callback']
+        };
+    }
+});
+
+app.use(
+    mcpAuthRouter({
+        provider: proxyProvider,
+        issuerUrl: new URL('http://auth.external.com'),
+        baseUrl: new URL('http://mcp.example.com'),
+        serviceDocumentationUrl: new URL('https://docs.example.com/')
+    })
+);
+```
+
+This setup allows you to:
+
+- Forward OAuth requests to an external provider
+- Add custom token validation logic
+- Manage client registrations
+- Provide custom documentation URLs
+- Maintain control over the OAuth flow while delegating to an external provider
+
+### Backwards Compatibility
+
+Clients and servers with StreamableHttp transport can maintain [backwards compatibility](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#backwards-compatibility) with the deprecated HTTP+SSE transport (from protocol version 2024-11-05) as follows
+
+#### Client-Side Compatibility
+
+For clients that need to work with both Streamable HTTP and older SSE servers:
+
+```typescript
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
+let client: Client | undefined = undefined;
+const baseUrl = new URL(url);
+try {
+    client = new Client({
+        name: 'streamable-http-client',
+        version: '1.0.0'
+    });
+    const transport = new StreamableHTTPClientTransport(new URL(baseUrl));
+    await client.connect(transport);
+    console.log('Connected using Streamable HTTP transport');
+} catch (error) {
+    // If that fails with a 4xx error, try the older SSE transport
+    console.log('Streamable HTTP connection failed, falling back to SSE transport');
+    client = new Client({
+        name: 'sse-client',
+        version: '1.0.0'
+    });
+    const sseTransport = new SSEClientTransport(baseUrl);
+    await client.connect(sseTransport);
+    console.log('Connected using SSE transport');
+}
+```
+
+#### Server-Side Compatibility
+
+For servers that need to support both Streamable HTTP and older clients:
+
+```typescript
+import express from 'express';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js';
+
+const server = new McpServer({
+    name: 'backwards-compatible-server',
+    version: '1.0.0'
+});
+
+// ... set up server resources, tools, and prompts ...
+
+const app = express();
+app.use(express.json());
+
+// Store transports for each session type
+const transports = {
+    streamable: {} as Record<string, StreamableHTTPServerTransport>,
+    sse: {} as Record<string, SSEServerTransport>
+};
+
+// Modern Streamable HTTP endpoint
+app.all('/mcp', async (req, res) => {
+    // Handle Streamable HTTP transport for modern clients
+    // Implementation as shown in the "With Session Management" example
+    // ...
+});
+
+// Legacy SSE endpoint for older clients
+app.get('/sse', async (req, res) => {
+    // Create SSE transport for legacy clients
+    const transport = new SSEServerTransport('/messages', res);
+    transports.sse[transport.sessionId] = transport;
+
+    res.on('close', () => {
+        delete transports.sse[transport.sessionId];
+    });
+
+    await server.connect(transport);
+});
+
+// Legacy message endpoint for older clients
+app.post('/messages', async (req, res) => {
+    const sessionId = req.query.sessionId as string;
+    const transport = transports.sse[sessionId];
+    if (transport) {
+        await transport.handlePostMessage(req, res, req.body);
+    } else {
+        res.status(400).send('No transport found for sessionId');
+    }
+});
+
+app.listen(3000);
+```
+
+**Note**: The SSE transport is now deprecated in favor of Streamable HTTP. New implementations should use Streamable HTTP, and existing SSE implementations should plan to migrate.
+
+## Documentation
+
+- [Model Context Protocol documentation](https://modelcontextprotocol.io)
+- [MCP Specification](https://spec.modelcontextprotocol.io)
+- [Example Servers](https://github.com/modelcontextprotocol/servers)
+
+## Contributing
+
+Issues and pull requests are welcome on GitHub at <https://github.com/modelcontextprotocol/typescript-sdk>.
+
+## License
+
+This project is licensed under the MIT License—see the [LICENSE](LICENSE) file for details.

--- a/test_mcp_tools.py
+++ b/test_mcp_tools.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+Functional test for TickTick MCP server tools.
+Tests filter_tasks and other tools with actual API calls.
+"""
+
+import os
+import sys
+import asyncio
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
+
+# Import after loading env
+from ticktick_mcp.src.server import (
+    initialize_client, filter_tasks, get_projects, 
+    get_project_tasks, create_task, engaged, next_actions
+)
+
+async def test_tools():
+    """Test the actual tool functions."""
+    
+    print("=" * 70)
+    print("Functional Test: TickTick MCP Server Tools")
+    print("=" * 70)
+    
+    # Initialize client
+    print("\n1. Initializing TickTick client...")
+    if not initialize_client():
+        print("❌ Failed to initialize client. Check your .env file.")
+        return False
+    print("✅ Client initialized successfully")
+    
+    # Test get_projects
+    print("\n2. Testing get_projects tool...")
+    try:
+        result = await get_projects()
+        if "Error" in result or "Failed" in result:
+            print(f"❌ Error: {result}")
+            return False
+        print("✅ get_projects working")
+        print(f"   Result preview: {result[:100]}...")
+    except Exception as e:
+        print(f"❌ Exception: {e}")
+        return False
+    
+    # Test filter_tasks with different parameters
+    print("\n3. Testing filter_tasks tool...")
+    
+    test_cases = [
+        ("all tasks", {}),
+        ("overdue tasks", {"date_filter": "overdue"}),
+        ("today tasks", {"date_filter": "today"}),
+        ("high priority", {"priority": 5}),
+        ("all tasks (default)", {"date_filter": "all"}),
+    ]
+    
+    for test_name, params in test_cases:
+        try:
+            print(f"   Testing: {test_name}")
+            result = await filter_tasks(**params)
+            if "Error" in result or "Failed" in result:
+                print(f"      ⚠️  Warning: {result[:100]}")
+            else:
+                print(f"      ✅ Success - returned {len(result)} characters")
+        except Exception as e:
+            print(f"      ❌ Exception: {e}")
+            return False
+    
+    # Test filter_tasks with invalid parameters
+    print("\n4. Testing filter_tasks validation...")
+    try:
+        result = await filter_tasks(date_filter="invalid")
+        if "Invalid date_filter" in result:
+            print("   ✅ Invalid date_filter properly rejected")
+        else:
+            print(f"   ⚠️  Unexpected response: {result[:100]}")
+    except Exception as e:
+        print(f"   ❌ Exception: {e}")
+    
+    try:
+        result = await filter_tasks(priority=99)
+        if "Invalid priority" in result:
+            print("   ✅ Invalid priority properly rejected")
+        else:
+            print(f"   ⚠️  Unexpected response: {result[:100]}")
+    except Exception as e:
+        print(f"   ❌ Exception: {e}")
+    
+    # Test prompts
+    print("\n5. Testing prompts...")
+    try:
+        result = await engaged()
+        if isinstance(result, list) and len(result) > 0:
+            print("   ✅ engaged prompt returns valid format")
+            if 'role' in result[0] and 'content' in result[0]:
+                print("   ✅ Prompt message structure correct")
+        else:
+            print(f"   ❌ Invalid format: {type(result)}")
+    except Exception as e:
+        print(f"   ❌ Exception: {e}")
+    
+    try:
+        result = await next_actions()
+        if isinstance(result, list) and len(result) > 0:
+            print("   ✅ next_actions prompt returns valid format")
+            if 'role' in result[0] and 'content' in result[0]:
+                print("   ✅ Prompt message structure correct")
+        else:
+            print(f"   ❌ Invalid format: {type(result)}")
+    except Exception as e:
+        print(f"   ❌ Exception: {e}")
+    
+    # Test get_project_tasks if we have projects
+    print("\n6. Testing get_project_tasks...")
+    try:
+        projects_result = await get_projects()
+        if "inbox" in projects_result.lower() or "project" in projects_result.lower():
+            # Try to get inbox tasks
+            result = await get_project_tasks("inbox")
+            if "Error" not in result and "Failed" not in result:
+                print("   ✅ get_project_tasks('inbox') working")
+            else:
+                print(f"   ⚠️  Note: {result[:100]}")
+        else:
+            print("   ⚠️  Could not determine project structure")
+    except Exception as e:
+        print(f"   ⚠️  Exception (non-critical): {e}")
+    
+    print("\n" + "=" * 70)
+    print("✅ All functional tests completed!")
+    print("=" * 70)
+    return True
+
+if __name__ == "__main__":
+    try:
+        success = asyncio.run(test_tools())
+        sys.exit(0 if success else 1)
+    except KeyboardInterrupt:
+        print("\n\n⚠️  Test interrupted by user")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n\n❌ Test failed with exception: {e}")
+        import traceback
+        traceback.print_exc()
+        sys.exit(1)

--- a/ticktick_mcp/src/server.py
+++ b/ticktick_mcp/src/server.py
@@ -114,7 +114,15 @@ def format_project(project: Dict) -> str:
 
 @mcp.tool()
 async def get_projects() -> str:
-    """Get all projects from TickTick."""
+    """
+    Get all projects from TickTick.
+    
+    Returns:
+        Formatted list of all projects with their details (ID, name, color, view mode, etc.).
+    
+    Example:
+        Use this to see all available projects before creating tasks or filtering by project.
+    """
     if not ticktick:
         if not initialize_client():
             return "Failed to initialize TickTick client. Please check your API credentials."
@@ -142,7 +150,13 @@ async def get_project(project_id: str) -> str:
     Get details about a specific project.
     
     Args:
-        project_id: ID of the project
+        project_id: ID of the project. Use "inbox" for the inbox project.
+    
+    Returns:
+        Formatted project details including name, ID, color, view mode, and status.
+    
+    Example:
+        get_project("6226ff9877acee87727f6bca") - Get details for a specific project
     """
     if not ticktick:
         if not initialize_client():
@@ -165,6 +179,13 @@ async def get_project_tasks(project_id: str) -> str:
     
     Args:
         project_id: ID of the project. Use "inbox" to access your TickTick inbox tasks.
+    
+    Returns:
+        Formatted list of all tasks in the project with their details (title, priority, due dates, status, etc.).
+    
+    Example:
+        get_project_tasks("inbox") - Get all tasks in your inbox
+        get_project_tasks("6226ff9877acee87727f6bca") - Get all tasks in a specific project
     """
     if not ticktick:
         if not initialize_client():
@@ -194,8 +215,14 @@ async def get_task(project_id: str, task_id: str) -> str:
     Get details about a specific task.
     
     Args:
-        project_id: ID of the project. Use "inbox" to access your TickTick inbox tasks.
+        project_id: ID of the project. Use "inbox" for inbox tasks.
         task_id: ID of the task
+    
+    Returns:
+        Formatted task details including title, content, priority, dates, status, and subtasks.
+    
+    Example:
+        get_task("inbox", "63b7bebb91c0a5474805fcd4") - Get details for a specific task
     """
     if not ticktick:
         if not initialize_client():
@@ -224,12 +251,25 @@ async def create_task(
     Create a new task in TickTick.
     
     Args:
-        title: Task title
-        project_id: ID of the project to add the task to. Use "inbox" to create tasks in your TickTick inbox.
+        title: Task title (required)
+            Example: "Review Q4 report"
+        project_id: ID of the project to add the task to (required)
+            Use "inbox" to create tasks in your TickTick inbox.
+            Example: "inbox" or "6226ff9877acee87727f6bca"
         content: Task description/content (optional)
+            Example: "Review all sections and provide feedback"
         start_date: Start date in ISO format YYYY-MM-DDThh:mm:ss+0000 (optional)
+            Example: "2025-11-05T09:00:00+0000"
         due_date: Due date in ISO format YYYY-MM-DDThh:mm:ss+0000 (optional)
-        priority: Priority level (0: None, 1: Low, 3: Medium, 5: High) (optional)
+            Example: "2025-11-05T18:00:00+0000"
+        priority: Priority level (optional, default 0)
+            0 = None, 1 = Low, 3 = Medium, 5 = High
+    
+    Returns:
+        Formatted task details including ID for future updates.
+    
+    Example:
+        create_task("Buy groceries", "inbox", priority=3, due_date="2025-11-05T18:00:00+0000")
     """
     if not ticktick:
         if not initialize_client():
@@ -280,13 +320,23 @@ async def update_task(
     Update an existing task in TickTick.
     
     Args:
-        task_id: ID of the task to update
-        project_id: ID of the project the task belongs to. Use "inbox" for inbox tasks.
+        task_id: ID of the task to update (required)
+        project_id: ID of the project the task belongs to (required). Use "inbox" for inbox tasks.
         title: New task title (optional)
+            Example: "Review Q4 report - Updated"
         content: New task description/content (optional)
         start_date: New start date in ISO format YYYY-MM-DDThh:mm:ss+0000 (optional)
+            Example: "2025-11-05T09:00:00+0000"
         due_date: New due date in ISO format YYYY-MM-DDThh:mm:ss+0000 (optional)
-        priority: New priority level (0: None, 1: Low, 3: Medium, 5: High) (optional)
+            Example: "2025-11-06T18:00:00+0000"
+        priority: New priority level (optional)
+            0 = None, 1 = Low, 3 = Medium, 5 = High
+    
+    Returns:
+        Formatted updated task details.
+    
+    Example:
+        update_task("63b7bebb91c0a5474805fcd4", "inbox", priority=5) - Update task priority to high
     """
     if not ticktick:
         if not initialize_client():
@@ -330,8 +380,14 @@ async def complete_task(project_id: str, task_id: str) -> str:
     Mark a task as complete.
     
     Args:
-        project_id: ID of the project. Use "inbox" for inbox tasks.
-        task_id: ID of the task
+        project_id: ID of the project (required). Use "inbox" for inbox tasks.
+        task_id: ID of the task to complete (required)
+    
+    Returns:
+        Confirmation message indicating the task was marked as complete.
+    
+    Example:
+        complete_task("inbox", "63b7bebb91c0a5474805fcd4") - Mark a task as done
     """
     if not ticktick:
         if not initialize_client():
@@ -350,11 +406,20 @@ async def complete_task(project_id: str, task_id: str) -> str:
 @mcp.tool()
 async def delete_task(project_id: str, task_id: str) -> str:
     """
-    Delete a task.
+    Delete a task permanently.
     
     Args:
-        project_id: ID of the project. Use "inbox" for inbox tasks.
-        task_id: ID of the task
+        project_id: ID of the project (required). Use "inbox" for inbox tasks.
+        task_id: ID of the task to delete (required)
+    
+    Returns:
+        Confirmation message indicating the task was deleted.
+    
+    Warning:
+        This action cannot be undone. Use complete_task if you want to mark a task as done instead.
+    
+    Example:
+        delete_task("inbox", "63b7bebb91c0a5474805fcd4") - Delete a task permanently
     """
     if not ticktick:
         if not initialize_client():
@@ -380,9 +445,18 @@ async def create_project(
     Create a new project in TickTick.
     
     Args:
-        name: Project name
-        color: Color code (hex format) (optional)
-        view_mode: View mode - one of list, kanban, or timeline (optional)
+        name: Project name (required)
+            Example: "Vacation Planning"
+        color: Color code in hex format (optional, default "#F18181")
+            Example: "#F18181" (red), "#5AC8FA" (blue), "#34C759" (green)
+        view_mode: View mode (optional, default "list")
+            Options: "list", "kanban", "timeline"
+    
+    Returns:
+        Formatted project details including the new project ID.
+    
+    Example:
+        create_project("Work Tasks", color="#5AC8FA", view_mode="kanban")
     """
     if not ticktick:
         if not initialize_client():
@@ -410,10 +484,19 @@ async def create_project(
 @mcp.tool()
 async def delete_project(project_id: str) -> str:
     """
-    Delete a project.
+    Delete a project permanently.
     
     Args:
-        project_id: ID of the project
+        project_id: ID of the project to delete (required)
+    
+    Returns:
+        Confirmation message indicating the project was deleted.
+    
+    Warning:
+        This action cannot be undone. All tasks in the project will also be deleted.
+    
+    Example:
+        delete_project("6226ff9877acee87727f6bca") - Delete a project
     """
     if not ticktick:
         if not initialize_client():
@@ -436,18 +519,70 @@ async def delete_project(project_id: str) -> str:
 
 PRIORITY_MAP = {0: "None", 1: "Low", 3: "Medium", 5: "High"}
 
+def _parse_ticktick_date(date_str: str) -> Optional[datetime]:
+    """
+    Parse a TickTick date string to a datetime object.
+    
+    TickTick API returns dates in format: "2019-11-14T03:00:00+0000"
+    (without microseconds, timezone as +0000 instead of +00:00)
+    
+    Args:
+        date_str: Date string from TickTick API
+        
+    Returns:
+        datetime object with timezone, or None if parsing fails
+    """
+    if not date_str:
+        return None
+    
+    try:
+        # Try parsing with microseconds first (in case API changes)
+        try:
+            return datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S.%f%z")
+        except ValueError:
+            pass
+        
+        # Normalize timezone format: +0000 -> +00:00 for Python's strptime
+        # Python's %z expects +00:00 format, not +0000
+        normalized_date = date_str
+        if len(date_str) > 5 and date_str[-5] in ['+', '-']:
+            # Format: YYYY-MM-DDTHH:MM:SS+0000 -> YYYY-MM-DDTHH:MM:SS+00:00
+            timezone_part = date_str[-5:]
+            if len(timezone_part) == 5 and timezone_part[-4:].isdigit():
+                sign = timezone_part[0]
+                hours = timezone_part[1:3]
+                minutes = timezone_part[3:5]
+                normalized_date = date_str[:-5] + f"{sign}{hours}:{minutes}"
+        
+        # Try parsing without microseconds
+        try:
+            return datetime.strptime(normalized_date, "%Y-%m-%dT%H:%M:%S%z")
+        except ValueError:
+            # Fallback: try with fromisoformat which handles both formats
+            try:
+                # Convert +0000 to +00:00 for fromisoformat
+                if normalized_date.endswith(('+0000', '-0000')):
+                    sign = normalized_date[-5]
+                    normalized_date = normalized_date[:-5] + f"{sign}00:00"
+                return datetime.fromisoformat(normalized_date.replace('Z', '+00:00'))
+            except (ValueError, AttributeError):
+                return None
+    except (ValueError, TypeError, AttributeError):
+        return None
+
 def _is_task_due_today(task: Dict[str, Any]) -> bool:
     """Check if a task is due today."""
     due_date = task.get('dueDate')
     if not due_date:
         return False
     
-    try:
-        task_due_date = datetime.strptime(due_date, "%Y-%m-%dT%H:%M:%S.%f%z").date()
-        today_date = datetime.now(timezone.utc).date()
-        return task_due_date == today_date
-    except (ValueError, TypeError):
+    task_dt = _parse_ticktick_date(due_date)
+    if not task_dt:
         return False
+    
+    task_due_date = task_dt.date()
+    today_date = datetime.now(timezone.utc).date()
+    return task_due_date == today_date
 
 def _is_task_overdue(task: Dict[str, Any]) -> bool:
     """Check if a task is overdue."""
@@ -455,11 +590,11 @@ def _is_task_overdue(task: Dict[str, Any]) -> bool:
     if not due_date:
         return False
     
-    try:
-        task_due = datetime.strptime(due_date, "%Y-%m-%dT%H:%M:%S.%f%z")
-        return task_due < datetime.now(timezone.utc)
-    except (ValueError, TypeError):
+    task_dt = _parse_ticktick_date(due_date)
+    if not task_dt:
         return False
+    
+    return task_dt < datetime.now(timezone.utc)
 
 def _is_task_due_in_days(task: Dict[str, Any], days: int) -> bool:
     """Check if a task is due in exactly X days."""
@@ -467,12 +602,13 @@ def _is_task_due_in_days(task: Dict[str, Any], days: int) -> bool:
     if not due_date:
         return False
     
-    try:
-        task_due_date = datetime.strptime(due_date, "%Y-%m-%dT%H:%M:%S.%f%z").date()
-        target_date = (datetime.now(timezone.utc) + timedelta(days=days)).date()
-        return task_due_date == target_date
-    except (ValueError, TypeError):
+    task_dt = _parse_ticktick_date(due_date)
+    if not task_dt:
         return False
+    
+    task_due_date = task_dt.date()
+    target_date = (datetime.now(timezone.utc) + timedelta(days=days)).date()
+    return task_due_date == target_date
 
 def _task_matches_search(task: Dict[str, Any], search_term: str) -> bool:
     """Check if a task matches the search term (case-insensitive)."""
@@ -578,365 +714,194 @@ def _get_project_tasks_by_filter(projects: List[Dict], filter_func, filter_name:
     
     return result
 
-# New MCP Tools for Tasks
+# Task Filtering Tool
 
 @mcp.tool()
-async def get_all_tasks() -> str:
-    """Get all tasks from TickTick. Ignores closed projects."""
-    if not ticktick:
-        if not initialize_client():
-            return "Failed to initialize TickTick client. Please check your API credentials."
-    
-    try:
-        projects = ticktick.get_projects()
-        if 'error' in projects:
-            return f"Error fetching projects: {projects['error']}"
-        
-        def all_tasks_filter(task: Dict[str, Any]) -> bool:
-            return True  # Include all tasks
-        
-        return _get_project_tasks_by_filter(projects, all_tasks_filter, "included")
-        
-    except Exception as e:
-        logger.error(f"Error in get_all_tasks: {e}")
-        return f"Error retrieving projects: {str(e)}"
-
-@mcp.tool()
-async def get_tasks_by_priority(priority_id: int) -> str:
+async def filter_tasks(
+    date_filter: str = "all",
+    priority: int = None,
+    search_term: str = None,
+    project_id: str = None
+) -> str:
     """
-    Get all tasks from TickTick by priority. Ignores closed projects.
-
-    Args:
-        priority_id: Priority of tasks to retrieve {0: "None", 1: "Low", 3: "Medium", 5: "High"}
-    """
-    if not ticktick:
-        if not initialize_client():
-            return "Failed to initialize TickTick client. Please check your API credentials."
-    
-    if priority_id not in PRIORITY_MAP:
-        return f"Invalid priority_id. Valid values: {list(PRIORITY_MAP.keys())}"
-    
-    try:
-        projects = ticktick.get_projects()
-        if 'error' in projects:
-            return f"Error fetching projects: {projects['error']}"
-        
-        def priority_filter(task: Dict[str, Any]) -> bool:
-            return task.get('priority', 0) == priority_id
-        
-        priority_name = f"{PRIORITY_MAP[priority_id]} ({priority_id})"
-        return _get_project_tasks_by_filter(projects, priority_filter, f"priority '{priority_name}'")
-        
-    except Exception as e:
-        logger.error(f"Error in get_tasks_by_priority: {e}")
-        return f"Error retrieving projects: {str(e)}"
-
-@mcp.tool()
-async def get_tasks_due_today() -> str:
-    """Get all tasks from TickTick that are due today. Ignores closed projects."""
-    if not ticktick:
-        if not initialize_client():
-            return "Failed to initialize TickTick client. Please check your API credentials."
-    
-    try:
-        projects = ticktick.get_projects()
-        if 'error' in projects:
-            return f"Error fetching projects: {projects['error']}"
-        
-        def today_filter(task: Dict[str, Any]) -> bool:
-            return _is_task_due_today(task)
-        
-        return _get_project_tasks_by_filter(projects, today_filter, "due today")
-        
-    except Exception as e:
-        logger.error(f"Error in get_tasks_due_today: {e}")
-        return f"Error retrieving projects: {str(e)}"
-
-@mcp.tool()
-async def get_overdue_tasks() -> str:
-    """Get all overdue tasks from TickTick. Ignores closed projects."""
-    if not ticktick:
-        if not initialize_client():
-            return "Failed to initialize TickTick client. Please check your API credentials."
-    
-    try:
-        projects = ticktick.get_projects()
-        if 'error' in projects:
-            return f"Error fetching projects: {projects['error']}"
-        
-        def overdue_filter(task: Dict[str, Any]) -> bool:
-            return _is_task_overdue(task)
-        
-        return _get_project_tasks_by_filter(projects, overdue_filter, "overdue")
-        
-    except Exception as e:
-        logger.error(f"Error in get_overdue_tasks: {e}")
-        return f"Error retrieving projects: {str(e)}"
-
-@mcp.tool()
-async def get_tasks_due_tomorrow() -> str:
-    """Get all tasks from TickTick that are due today. Ignores closed projects."""
-    if not ticktick:
-        if not initialize_client():
-            return "Failed to initialize TickTick client. Please check your API credentials."
-    
-    try:
-        projects = ticktick.get_projects()
-        if 'error' in projects:
-            return f"Error fetching projects: {projects['error']}"
-        
-        def today_filter(task: Dict[str, Any]) -> bool:
-            return _is_task_due_in_days(task, 1)
-        
-        return _get_project_tasks_by_filter(projects, today_filter, "due today")
-        
-    except Exception as e:
-        logger.error(f"Error in get_tasks_due_today: {e}")
-        return f"Error retrieving projects: {str(e)}"
-    
-@mcp.tool()
-async def get_tasks_due_in_days(days: int) -> str:
-    """
-    Get all tasks from TickTick that are due in exactly X days. Ignores closed projects.
+    Filter tasks across all projects with flexible criteria. Combine multiple filters to find exactly what you need.
     
     Args:
-        days: Number of days from today (0 = today, 1 = tomorrow, etc.)
+        date_filter: Filter by date range. Options:
+            - "all" (default): All tasks regardless of date
+            - "today": Tasks due today
+            - "tomorrow": Tasks due tomorrow
+            - "overdue": Tasks that are past their due date
+            - "this_week": Tasks due within the next 7 days
+            - "next_7_days": Same as "this_week"
+        priority: Filter by priority level. Options:
+            - None (default): Any priority
+            - 0: None priority
+            - 1: Low priority
+            - 3: Medium priority
+            - 5: High priority
+        search_term: Search for text in task title, content, or subtask titles (case-insensitive).
+            Example: "client meeting" will find tasks containing "client meeting"
+        project_id: Filter to a specific project. Use "inbox" for inbox tasks, or a project ID.
+            If None, searches across all projects.
+    
+    Returns:
+        Formatted list of matching tasks grouped by project.
+    
+    Examples:
+        filter_tasks(date_filter="overdue") - All overdue tasks
+        filter_tasks(priority=5) - All high priority tasks
+        filter_tasks(date_filter="today", priority=5) - High priority tasks due today
+        filter_tasks(search_term="client meeting") - Search for tasks about client meetings
+        filter_tasks(project_id="inbox", date_filter="this_week") - Inbox tasks due this week
+        filter_tasks(priority=3, search_term="review") - Medium priority tasks containing "review"
     """
     if not ticktick:
         if not initialize_client():
             return "Failed to initialize TickTick client. Please check your API credentials."
     
-    if days < 0:
-        return "Days must be a non-negative integer."
+    # Validate date_filter
+    valid_date_filters = ["all", "today", "tomorrow", "overdue", "this_week", "next_7_days"]
+    if date_filter not in valid_date_filters:
+        return f"Invalid date_filter. Valid values: {', '.join(valid_date_filters)}"
     
-    try:
-        projects = ticktick.get_projects()
-        if 'error' in projects:
-            return f"Error fetching projects: {projects['error']}"
-        
-        def days_filter(task: Dict[str, Any]) -> bool:
-            return _is_task_due_in_days(task, days)
-        
-        day_description = "today" if days == 0 else f"in {days} day{'s' if days != 1 else ''}"
-        return _get_project_tasks_by_filter(projects, days_filter, f"due {day_description}")
-        
-    except Exception as e:
-        logger.error(f"Error in get_tasks_due_in_days: {e}")
-        return f"Error retrieving projects: {str(e)}"
-
-@mcp.tool()
-async def get_tasks_due_this_week() -> str:
-    """Get all tasks from TickTick that are due within the next 7 days. Ignores closed projects."""
-    if not ticktick:
-        if not initialize_client():
-            return "Failed to initialize TickTick client. Please check your API credentials."
+    # Validate priority if provided
+    if priority is not None and priority not in PRIORITY_MAP:
+        return f"Invalid priority. Valid values: {list(PRIORITY_MAP.keys())}"
     
-    try:
-        projects = ticktick.get_projects()
-        if 'error' in projects:
-            return f"Error fetching projects: {projects['error']}"
-        
-        def week_filter(task: Dict[str, Any]) -> bool:
-            due_date = task.get('dueDate')
-            if not due_date:
-                return False
-            
-            try:
-                task_due_date = datetime.strptime(due_date, "%Y-%m-%dT%H:%M:%S.%f%z").date()
-                today = datetime.now(timezone.utc).date()
-                week_from_today = today + timedelta(days=7)
-                return today <= task_due_date <= week_from_today
-            except (ValueError, TypeError):
-                return False
-        
-        return _get_project_tasks_by_filter(projects, week_filter, "due this week")
-        
-    except Exception as e:
-        logger.error(f"Error in get_tasks_due_this_week: {e}")
-        return f"Error retrieving projects: {str(e)}"
-
-@mcp.tool()
-async def search_tasks(search_term: str) -> str:
-    """
-    Search for tasks in TickTick by title, content, or subtask titles. Ignores closed projects.
-    
-    Args:
-        search_term: Text to search for (case-insensitive)
-    """
-    if not ticktick:
-        if not initialize_client():
-            return "Failed to initialize TickTick client. Please check your API credentials."
-    
-    if not search_term.strip():
+    # Validate search_term if provided
+    if search_term is not None and not search_term.strip():
         return "Search term cannot be empty."
     
     try:
-        projects = ticktick.get_projects()
-        if 'error' in projects:
-            return f"Error fetching projects: {projects['error']}"
+        # Get projects to filter
+        if project_id:
+            # Single project filter
+            projects_data = ticktick.get_projects()
+            if 'error' in projects_data:
+                return f"Error fetching projects: {projects_data['error']}"
+            
+            # Find the specific project
+            project = None
+            for p in projects_data:
+                if p.get('id') == project_id or (project_id == "inbox" and p.get('name', '').lower() == "inbox"):
+                    project = p
+                    break
+            
+            if not project:
+                return f"Project '{project_id}' not found."
+            
+            projects = [project]
+        else:
+            # All projects
+            projects = ticktick.get_projects()
+            if 'error' in projects:
+                return f"Error fetching projects: {projects['error']}"
         
-        def search_filter(task: Dict[str, Any]) -> bool:
-            return _task_matches_search(task, search_term)
-        
-        return _get_project_tasks_by_filter(projects, search_filter, f"matching '{search_term}'")
-        
-    except Exception as e:
-        logger.error(f"Error in search_tasks: {e}")
-        return f"Error retrieving projects: {str(e)}"
-
-@mcp.tool()
-async def batch_create_tasks(tasks: List[Dict[str, Any]]) -> str:
-    """
-    Create multiple tasks in TickTick at once
-    
-    Args:
-        tasks: List of task dictionaries. Each task must contain:
-            - title (required): Task Name
-            - project_id (required): ID of the project for the task
-            - content (optional): Task description
-            - start_date (optional): Start date in user timezone (YYYY-MM-DDTHH:mm:ss or with timezone)
-            - due_date (optional): Due date in user timezone (YYYY-MM-DDTHH:mm:ss or with timezone)  
-            - priority (optional): Priority level {0: "None", 1: "Low", 3: "Medium", 5: "High"}
-    
-    Example:
-        tasks = [
-            {"title": "Example A", "project_id": "1234ABC", "priority": 5},
-            {"title": "Example B", "project_id": "1234XYZ", "content": "Description", "start_date": "2025-07-18T10:00:00", "due_date": "2025-07-19T10:00:00"}
-        ]
-    """
-    if not ticktick:
-        if not initialize_client():
-            return "Failed to initialize TickTick client. Please check your API credentials."
-    
-    if not tasks:
-        return "No tasks provided. Please provide a list of tasks to create."
-    
-    if not isinstance(tasks, list):
-        return "Tasks must be provided as a list of dictionaries."
-    
-    # Validate all tasks before creating any
-    validation_errors = []
-    for i, task_data in enumerate(tasks):
-        if not isinstance(task_data, dict):
-            validation_errors.append(f"Task {i + 1}: Must be a dictionary")
-            continue
-        
-        error = _validate_task_data(task_data, i)
-        if error:
-            validation_errors.append(error)
-    
-    if validation_errors:
-        return "Validation errors found:\n" + "\n".join(validation_errors)
-    
-    # Create tasks one by one and collect results
-    created_tasks = []
-    failed_tasks = []
-    
-    try:
-        for i, task_data in enumerate(tasks):
-            try:
-                # Extract task parameters with defaults
-                title = task_data['title']
-                project_id = task_data['project_id']
-                content = task_data.get('content')
-                start_date = task_data.get('start_date')
-                due_date = task_data.get('due_date')
-                priority = task_data.get('priority', 0)
-                
-                # Create the task
-                result = ticktick.create_task(
-                    title=title,
-                    project_id=project_id,
-                    content=content,
-                    start_date=start_date,
-                    due_date=due_date,
-                    priority=priority
-                )
-                
-                if 'error' in result:
-                    failed_tasks.append(f"Task {i + 1} ('{title}'): {result['error']}")
+        # Build filter function
+        def task_filter(task: Dict[str, Any]) -> bool:
+            # Date filter
+            if date_filter == "all":
+                date_match = True
+            elif date_filter == "today":
+                date_match = _is_task_due_today(task)
+            elif date_filter == "tomorrow":
+                date_match = _is_task_due_in_days(task, 1)
+            elif date_filter == "overdue":
+                date_match = _is_task_overdue(task)
+            elif date_filter in ["this_week", "next_7_days"]:
+                due_date = task.get('dueDate')
+                if not due_date:
+                    date_match = False
                 else:
-                    created_tasks.append((i + 1, title, result))
-                    
-            except Exception as e:
-                failed_tasks.append(f"Task {i + 1} ('{task_data.get('title', 'Unknown')}'): {str(e)}")
+                    task_dt = _parse_ticktick_date(due_date)
+                    if not task_dt:
+                        date_match = False
+                    else:
+                        task_due_date = task_dt.date()
+                        today = datetime.now(timezone.utc).date()
+                        week_from_today = today + timedelta(days=7)
+                        date_match = today <= task_due_date <= week_from_today
+            else:
+                date_match = True
+            
+            # Priority filter
+            if priority is None:
+                priority_match = True
+            else:
+                priority_match = task.get('priority', 0) == priority
+            
+            # Search filter
+            if search_term is None:
+                search_match = True
+            else:
+                search_match = _task_matches_search(task, search_term)
+            
+            return date_match and priority_match and search_match
         
-        # Format the results
-        result_message = f"Batch task creation completed.\n\n"
-        result_message += f"Successfully created: {len(created_tasks)} tasks\n"
-        result_message += f"Failed: {len(failed_tasks)} tasks\n\n"
+        # Build filter description
+        filter_parts = []
+        if date_filter != "all":
+            filter_parts.append(date_filter)
+        if priority is not None:
+            filter_parts.append(f"priority {PRIORITY_MAP[priority]}")
+        if search_term:
+            filter_parts.append(f"matching '{search_term}'")
+        if project_id:
+            filter_parts.append(f"in project '{project_id}'")
         
-        if created_tasks:
-            result_message += "✅ Successfully Created Tasks:\n"
-            for task_num, title, task_obj in created_tasks:
-                result_message += f"{task_num}. {title} (ID: {task_obj.get('id', 'Unknown')})\n"
-            result_message += "\n"
+        filter_name = " and ".join(filter_parts) if filter_parts else "all tasks"
         
-        if failed_tasks:
-            result_message += "❌ Failed Tasks:\n"
-            for error in failed_tasks:
-                result_message += f"{error}\n"
-        
-        return result_message
+        return _get_project_tasks_by_filter(projects, task_filter, filter_name)
         
     except Exception as e:
-        logger.error(f"Error in batch_create_tasks: {e}")
-        return f"Error during batch task creation: {str(e)}"
+        logger.error(f"Error in filter_tasks: {e}")
+        return f"Error filtering tasks: {str(e)}"
 
-# New MCP Tools for Getting things done framework (Priority / Due Dates)
+# GTD Workflow Prompts
 
-@mcp.tool()
-async def get_engaged_tasks() -> str:
+@mcp.prompt()
+async def engaged() -> list:
     """
-    Get all tasks from TickTick that are "Engaged".
-    This includes tasks marked as high priority (5), due today or overdue.
-    """
-    if not ticktick:
-        if not initialize_client():
-            return "Failed to initialize TickTick client. Please check your API credentials."
+    Show me tasks that need immediate attention (GTD "Engaged" workflow).
     
-    try:
-        projects = ticktick.get_projects()
-        if 'error' in projects:
-            return f"Error fetching projects: {projects['error']}"
-        
-        def engaged_filter(task: Dict[str, Any]) -> bool:
-            is_high_priority = task.get('priority', 0) == 5
-            is_overdue = _is_task_overdue(task)
-            is_today = _is_task_due_today(task)
-            return is_high_priority or is_overdue or is_today
-        
-        return _get_project_tasks_by_filter(projects, engaged_filter, "engaged")
-        
-    except Exception as e:
-        logger.error(f"Error in get_engaged_tasks: {e}")
-        return f"Error retrieving projects: {str(e)}"
-
-@mcp.tool()
-async def get_next_tasks() -> str:
-    """
-    Get all tasks from TickTick that are "Next".
-    This includes tasks marked as medium priority (3) or due tomorrow.
-    """
-    if not ticktick:
-        if not initialize_client():
-            return "Failed to initialize TickTick client. Please check your API credentials."
+    This prompt helps you focus on tasks that require immediate action:
+    - High priority tasks (priority 5)
+    - Overdue tasks
+    - Tasks due today
     
-    try:
-        projects = ticktick.get_projects()
-        if 'error' in projects:
-            return f"Error fetching projects: {projects['error']}"
-        
-        def next_filter(task: Dict[str, Any]) -> bool:
-            is_medium_priority = task.get('priority', 0) == 3
-            is_due_tomorrow = _is_task_due_in_days(task, 1)
-            return is_medium_priority or is_due_tomorrow
-        
-        return _get_project_tasks_by_filter(projects, next_filter, "next")
-        
-    except Exception as e:
-        logger.error(f"Error in get_next_tasks: {e}")
-        return f"Error retrieving projects: {str(e)}"
+    Use this when you need to see what demands your attention right now.
+    """
+    return [
+        {
+            "role": "user",
+            "content": {
+                "type": "text",
+                "text": "Use the filter_tasks tool to show me all engaged tasks. Engaged tasks are: (1) tasks with priority=5 OR (2) tasks with date_filter='overdue' OR (3) tasks with date_filter='today'. Format the results as a clear, actionable list with project groupings."
+            }
+        }
+    ]
+
+@mcp.prompt()
+async def next_actions() -> list:
+    """
+    Show me tasks for next actions (GTD "Next" workflow).
+    
+    This prompt helps you identify tasks ready for action:
+    - Medium priority tasks (priority 3)
+    - Tasks due tomorrow
+    
+    Use this when planning what to work on next.
+    """
+    return [
+        {
+            "role": "user",
+            "content": {
+                "type": "text",
+                "text": "Use the filter_tasks tool to show me my next actions. Next actions are: (1) tasks with priority=3 OR (2) tasks with date_filter='tomorrow'. Format the results as an organized, prioritized list."
+            }
+        }
+    ]
 
 @mcp.tool()
 async def create_subtask(
@@ -950,11 +915,21 @@ async def create_subtask(
     Create a subtask for a parent task within the same project.
     
     Args:
-        subtask_title: Title of the subtask
-        parent_task_id: ID of the parent task
-        project_id: ID of the project (must be same for both parent and subtask)
+        subtask_title: Title of the subtask (required)
+            Example: "Buy milk"
+        parent_task_id: ID of the parent task (required)
+            Example: "63b7bebb91c0a5474805fcd4"
+        project_id: ID of the project (required). Must match the parent task's project.
+            Use "inbox" if the parent task is in the inbox.
         content: Optional content/description for the subtask
-        priority: Priority level (0: None, 1: Low, 3: Medium, 5: High) (optional)
+        priority: Priority level (optional, default 0)
+            0 = None, 1 = Low, 3 = Medium, 5 = High
+    
+    Returns:
+        Formatted subtask details including ID.
+    
+    Example:
+        create_subtask("Buy milk", "63b7bebb91c0a5474805fcd4", "inbox", priority=1)
     """
     if not ticktick:
         if not initialize_client():


### PR DESCRIPTION
## Summary

This PR streamlines the TickTick MCP server by reducing the number of tools from 22 to 12 tools + 2 prompts (45% reduction).

## Changes

### Tool Consolidation
- ✅ Consolidated 8 filtering tools → 1 flexible filter_tasks tool
- ✅ Removed batch_create_tasks

### GTD Workflows
- ✅ Converted GTD tools to user-driven prompts (/engaged, /next_actions)

### Bug Fixes
- ✅ Fixed critical date parsing bug with _parse_ticktick_date() helper

### Documentation
- ✅ Enhanced all tool descriptions with examples
- ✅ Updated README.md with new structure

## Final Result
**Before:** 22 tools  
**After:** 12 tools + 2 prompts  
**Reduction:** 45%